### PR TITLE
Add documentation to run app in heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,22 @@ You are going to have to sign up to github to clone code. If you want to avoid t
 * Go to the cloned directory: `cd react-tictactoe`.
 * Run the app `docker-compose up`
 * Open browser in [http://localhost:8000](http://localhost:8000)
+
+### Using Heroku
+1. Install [heroku cli](https://devcenter.heroku.com/articles/heroku-cli)
+2. Create new app to Heroku
+    * [https://dashboard.heroku.com/new-app](https://dashboard.heroku.com/new-app)
+3. Clone this repository and cd into it
+    * *git clone https://github.com/koodi101/react-tictactoe.git && cd react-tictactoe*
+4. Login to heroku on command line
+    * *heroku login*
+5. Add heroku remote to git configuration
+    * *heroku git:remote -a \<app name\>*
+6. Tell heroku to also install dependencies for development use
+    * *heroku config:set NPM_CONFIG_PRODUCTION=false*
+7. Tell our application to use port 80 instead of 8080
+    * *heroku config:set PORT=80*
+8. Push our code to heroku
+    * *git push heroku master*
+
+


### PR DESCRIPTION
This is how it goes.

It will launch development server in heroku and the hot reload stuff will throw errors into console, because it can't connect to weird ports that it would like to.

But for our purposes – good enough.